### PR TITLE
Added correct RedHat-7 defaults to the vars

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,6 +18,10 @@ _mysql_packages:
     - MySQL-python
   Archlinux:
     - mariadb
+  RedHat-7:
+    - mariadb-devel
+    - mariadb-server
+    - MySQL-python
   CentOS-7:
     - mariadb-devel
     - mariadb-server


### PR DESCRIPTION
---
name: Pull request to work with RHEL 7
about: There is no default for RHEL 7 and it uses the defaults that aren't correct

---

Copied the Centos 7 defaults to the RedHat-7