### PR TITLE
Fix for passwords with #

### DIFF
--- a/templates/my.cnf.j2
+++ b/templates/my.cnf.j2
@@ -1,5 +1,5 @@
 {{ ansible_managed | comment }}
 
 [client]
-user=root
-password={{ mysql_root_password }}
+user='root'
+password='{{ mysql_root_password }}'


### PR DESCRIPTION
**Describe the change**
Without `''` a valid password containing a `#` char, like: `test#123` does not work, because `#` is interpreted as a comment.

**Testing**

Run role with the following root password:
```yaml
mysql_root_password: "test#123"
```

Switch to user root and try to run `mysql`:
```
sudo mysql
```

Without this change it fails.